### PR TITLE
修正

### DIFF
--- a/db/migrate/20200327045117_create_likes.rb
+++ b/db/migrate/20200327045117_create_likes.rb
@@ -7,8 +7,6 @@ class CreateLikes < ActiveRecord::Migration[5.1]
       t.timestamps
 
     end
-    add_index :users, :user_id
-    add_index :microposts, :micropost_id
     add_index :likes, [:user_id, :micropost_id], unique: true
   end
 end


### PR DESCRIPTION
PG::UndefinedColumn: ERROR:  column “user_id” does not exist
: CREATE  INDEX  “index_users_on_user_id” ON “users”  (“user_id”)
ヘロクの修正